### PR TITLE
MOS-641: Instruction text appears above field

### DIFF
--- a/src/components/Field/InstructionText.styled.ts
+++ b/src/components/Field/InstructionText.styled.ts
@@ -5,7 +5,7 @@ export const InstructionTextWrapper = styled.div`
   border-left: ${theme.borders.simplyGray};
   height: 51px;
   margin-left: auto;
-  margin-top: ${pr => pr.labelMargin === "16px" ? "52px" : "44px"}
+  margin-top: ${pr => pr.labelMargin === "16px" ? "52px" : "44px"};
   padding-left: 20px;
   width: 400px;
 


### PR DESCRIPTION
# What's include

- Added semicolon to styled component for InstructionText.styled.ts